### PR TITLE
chore: remove empty file with invalid Windows filename

### DIFF
--- a/30. What is Nginx?/README.md
+++ b/30. What is Nginx?/README.md
@@ -1,1 +1,0 @@
-# completed


### PR DESCRIPTION
Removed `30. What is Nginx?/README.md`, which was an empty file and
causing clone failures on Windows due to invalid characters (`?`) in the
path. This cleanup ensures smooth cloning across platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a placeholder README file containing no user-facing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->